### PR TITLE
Include the b2sum for the original data in the generated PDF file.

### DIFF
--- a/paperbackup-verify.sh
+++ b/paperbackup-verify.sh
@@ -4,10 +4,11 @@
 #   where backup.pdf should be the pdf created with paperbackup.py
 
 RESTOREPROG=$(dirname $0)/paperrestore.sh
+PAPERB2SUMPROG="$(dirname $0)/paperbackup.py --b2sum"
 
 rPDF=$( $RESTOREPROG $1 )
 
-bPDF=$(echo "$rPDF" | b2sum | cut -d ' ' -f 1 )
+bPDF=$(echo "$rPDF" | $PAPERB2SUMPROG )
 bEmbedded=$(pdftotext $1 - | grep b2sum -A2 | tail -2 | tr -d '\n')
 
 if [ "x$bPDF" == "x$bEmbedded" ]; then

--- a/paperbackup-verify.sh
+++ b/paperbackup-verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/bash
+
+# USAGE: paperbackup-verify.sh backup.pdf
+#   where backup.pdf should be the pdf created with paperbackup.py
+
+RESTOREPROG=$(dirname $0)/paperrestore.sh
+
+rPDF=$( $RESTOREPROG $1 )
+
+bPDF=$(echo "$rPDF" | b2sum | cut -d ' ' -f 1 )
+bEmbedded=$(pdftotext $1 - | grep b2sum -A2 | tail -2 | tr -d '\n')
+
+if [ "x$bPDF" == "x$bEmbedded" ]; then
+    echo "b2sums MATCH :-)"
+    echo
+    exit 0
+else
+    echo "Creating diff:"
+    echo "$rPDF" | diff ${1%.*} -
+    diffret=$?
+    echo
+    if [ $diffret -ne 0 ]; then
+        echo "diff and b2sums do NOT match!"
+        echo "restored b2sum from PDF: " $bPDF
+        echo "original b2sum embedded: " $bEmbedded
+        echo
+        exit 11
+    else
+        echo "diff matches but b2sum is missing."
+        echo
+        exit 1
+    fi
+fi

--- a/paperbackup-verify.sh
+++ b/paperbackup-verify.sh
@@ -4,30 +4,29 @@
 #   where backup.pdf should be the pdf created with paperbackup.py
 
 RESTOREPROG=$(dirname $0)/paperrestore.sh
-PAPERB2SUMPROG="$(dirname $0)/paperbackup.py --b2sum"
 
-rPDF=$( $RESTOREPROG $1 )
-
-bPDF=$(echo "$rPDF" | $PAPERB2SUMPROG )
-bEmbedded=$(pdftotext $1 - | grep b2sum -A2 | tail -2 | tr -d '\n')
+bPDF=$( $RESTOREPROG $1 | sha256sum | cut -d ' ' -f 1)
+bEmbedded=$(pdftotext $1 - | grep sha256sum -A1 | tail -1 | tr -d '\n')
 
 if [ "x$bPDF" == "x$bEmbedded" ]; then
-    echo "b2sums MATCH :-)"
+    echo "sha256sums MATCH :-)"
     echo
     exit 0
 else
     echo "Creating diff:"
-    echo "$rPDF" | diff ${1%.*} -
+    $RESTOREPROG $1 | diff ${1%.*} -
     diffret=$?
     echo
     if [ $diffret -ne 0 ]; then
-        echo "diff and b2sums do NOT match!"
-        echo "restored b2sum from PDF: " $bPDF
-        echo "original b2sum embedded: " $bEmbedded
+        echo "diff and sha256sums do NOT match!"
+        echo "restored sha256sum from PDF: " $bPDF
+        echo "original sha256sum embedded: " $bEmbedded
         echo
         exit 11
     else
-        echo "diff matches but b2sum is missing."
+        echo "diff matches but sha256sum is missing."
+        echo "restored sha256sum from PDF: " $bPDF
+        echo "original sha256sum embedded: " $bEmbedded
         echo
         exit 1
     fi

--- a/paperbackup.py
+++ b/paperbackup.py
@@ -35,6 +35,7 @@ import subprocess
 import qrencode
 from tempfile import mkstemp
 from datetime import datetime
+from shutil import which
 from PIL import Image
 from pyx import *
 
@@ -171,6 +172,9 @@ for line in splitlines:
 
     chksumlines.append(line)
 
+# we also want a checksum which the restored file should match
+b2sum = hashlib.blake2b(bytes(ascdata, 'utf8')).hexdigest()
+
 # add some documentation around the plaintest
 outlines=[]
 coldoc=" "*splitat
@@ -178,6 +182,10 @@ coldoc+=" | MD5"
 outlines.append(coldoc)
 outlines.extend(chksumlines)
 outlines.append("")
+outlines.append("")
+outlines.append("b2sum of input file (split over 2 lines):")
+outlines.append("%s"%b2sum[:64])
+outlines.append("%s"%b2sum[64:])
 outlines.append("")
 outlines.append("")
 outlines.append("--")
@@ -216,3 +224,16 @@ if ret != 0:
 
 os.remove(temp_text_path)
 os.remove(temp_barcode_path)
+
+verify_prog = which("paperbackup-verify.sh")
+if not verify_prog:
+    verify_prog = which("paperbackup-verify")
+if not verify_prog:
+    verify_prog = which(os.path.join(os.path.dirname(sys.argv[0]), "paperbackup-verify.sh"))
+if not verify_prog:
+    print("\n  NOTE:  Could not find 'paperbackup-verify' program which should have been")
+    print(  "           installed together with {}! ".format(sys.argv[0]))
+    verify_prog = "paperbackup-verify"
+print("\n  !!!!!!!!!")
+print("  ATTENTION:  Running '{} {}.pdf' NOW is STRONGLY advised to".format(verify_prog, just_filename))
+print("  !!!!!!!!!     verify that zbarimg can read back the generated qr codes!\n")

--- a/paperbackup.py
+++ b/paperbackup.py
@@ -35,7 +35,6 @@ import subprocess
 import qrencode
 from tempfile import mkstemp
 from datetime import datetime
-from shutil import which
 from PIL import Image
 from pyx import *
 
@@ -70,15 +69,6 @@ def finish_page(pdf, canv, pageno):
                              fittosize=0, centered=0))
 
 # main code
-
-if sys.argv[1] == "--b2sum":
-    if len(sys.argv) > 2:
-        with open(sys.argv[2], 'r') as ifile:
-            data = ''.join(ifile.readlines())
-    else:
-        data = ''.join(sys.stdin.readlines())
-    print(hashlib.blake2b(bytes(data, 'utf8')).hexdigest())
-    sys.exit(0)
 
 if len(sys.argv) != 2:
     raise RuntimeError('Usage {} FILENAME.asc'.format(sys.argv[0]))
@@ -182,7 +172,7 @@ for line in splitlines:
     chksumlines.append(line)
 
 # we also want a checksum which the restored file should match
-b2sum = hashlib.blake2b(bytes(ascdata, 'utf8')).hexdigest()
+checksum = hashlib.sha256(bytes(ascdata, 'utf8')).hexdigest()
 
 # add some documentation around the plaintest
 outlines=[]
@@ -192,9 +182,8 @@ outlines.append(coldoc)
 outlines.extend(chksumlines)
 outlines.append("")
 outlines.append("")
-outlines.append("b2sum of input file (split over 2 lines):")
-outlines.append("%s"%b2sum[:64])
-outlines.append("%s"%b2sum[64:])
+outlines.append("sha256sum of input file:")
+outlines.append("%s"%checksum)
 outlines.append("")
 outlines.append("")
 outlines.append("--")

--- a/paperbackup.py
+++ b/paperbackup.py
@@ -225,15 +225,5 @@ if ret != 0:
 os.remove(temp_text_path)
 os.remove(temp_barcode_path)
 
-verify_prog = which("paperbackup-verify.sh")
-if not verify_prog:
-    verify_prog = which("paperbackup-verify")
-if not verify_prog:
-    verify_prog = which(os.path.join(os.path.dirname(sys.argv[0]), "paperbackup-verify.sh"))
-if not verify_prog:
-    print("\n  NOTE:  Could not find 'paperbackup-verify' program which should have been")
-    print(  "           installed together with {}! ".format(sys.argv[0]))
-    verify_prog = "paperbackup-verify"
-print("\n  !!!!!!!!!")
-print("  ATTENTION:  Running '{} {}.pdf' NOW is STRONGLY advised to".format(verify_prog, just_filename))
-print("  !!!!!!!!!     verify that zbarimg can read back the generated qr codes!\n")
+print("Please now verify that the output can be restored by calling:")
+print("paperbackup-verify.sh {}.pdf".format(just_filename))

--- a/paperbackup.py
+++ b/paperbackup.py
@@ -71,6 +71,15 @@ def finish_page(pdf, canv, pageno):
 
 # main code
 
+if sys.argv[1] == "--b2sum":
+    if len(sys.argv) > 2:
+        with open(sys.argv[2], 'r') as ifile:
+            data = ''.join(ifile.readlines())
+    else:
+        data = ''.join(sys.stdin.readlines())
+    print(hashlib.blake2b(bytes(data, 'utf8')).hexdigest())
+    sys.exit(0)
+
 if len(sys.argv) != 2:
     raise RuntimeError('Usage {} FILENAME.asc'.format(sys.argv[0]))
 


### PR DESCRIPTION
This aids in verification:
 1) after creation, that a PDF was created which can be successfully
    restored --> see new paperbackup-verify.sh script which in this role
    automates the diff step from the README.
 2) after restoration, by manually running b2sum on the restored data
    and comparing to the printout, that the restoration has indeed produced
    the exact same data as had been in the original file. This step could be
    automated as well in the future if we get a "metadata chunk".

Dependencies for paperbackup-verify.sh besides bash: coreutils, pdftotext (from poppler-utils), grep, diff