### PR TITLE
paperbackup Dockerfile and run scripts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+# paperbackup Dockerfile
+# Copyright (C) 2024, Kamal Mostafa <kamal@whence.com>
+# License: MIT License as per <https://github.com/intra2net/paperbackup.git>
+
+# https://github.com/intra2net/paperbackup/issues/19
+# Use python:3.9 because:
+#   qrencode on python >=3.10 fails with:
+#     SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
+
+FROM python:3.9-bookworm
+
+# dependencies
+RUN apt update && apt-get install -y --no-install-recommends \
+        libqrencode-dev enscript ghostscript zbar-tools texlive poppler-utils
+RUN pip3 install pillow pyx qrencode
+
+# https://github.com/intra2net/paperbackup/issues/10
+# Preclude ERROR: attempt to perform an operation not allowed by the security policy `gs'
+# https://stackoverflow.com/questions/70655631/imagemagick-security-policy-error-in-github-workflow
+RUN sed -i 's/^.*policy.*coder.*none.*PDF.*//' /etc/ImageMagick-6/policy.xml
+
+# paperbackup
+RUN git clone https://github.com/intra2net/paperbackup.git
+
+ENTRYPOINT ["/paperbackup/paperbackup.py"]

--- a/docker/README-Docker.md
+++ b/docker/README-Docker.md
@@ -1,0 +1,32 @@
+# Dockerized PaperBackup
+
+PaperBackup <https://github.com/intra2net/paperbackup.git> is a command-line tool to create a QR-codes/barcodes to backup text files on paper;
+Copyright 2017 by Intra2net AG, Germany.
+
+This Dockerized version encapsulates `paperbackup` within a Docker container, allowing for deployment in various and otherwise incompatible environments.  In particular, this allows `paperbackup` to run on systems with more modern python installations (> 3.9) than the tool may require.
+
+### Building the Docker Image
+
+To build the `paperbackup` Docker image, clone the repository and navigate to the directory containing the Dockerfile -- or simply download the Dockerfile and the pair of shell-scripts from that directory -- then run:
+
+```bash
+docker build -t paperbackup .
+```
+
+### Running the Tool
+
+Use the included one-liner shell scripts `paperbackup.sh` and `paperbackup-verify.sh` to run the tool within the container:
+
+```bash
+./paperbackup.sh <inputfile>
+```
+
+```bash
+./paperbackup-verify.sh <inputfile.pdf>
+```
+
+## License
+
+MIT License as per <https://github.com/intra2net/paperbackup.git>.
+
+This simple Dockerfile was created by Kamal Mostafa <kamal@whence.com>.

--- a/docker/paperbackup-verify.sh
+++ b/docker/paperbackup-verify.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker run --rm --volume .:/app --workdir /app \
+	--entrypoint=/paperbackup/paperbackup-verify.sh paperbackup $*

--- a/docker/paperbackup.sh
+++ b/docker/paperbackup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm --volume .:/app --workdir /app paperbackup $*


### PR DESCRIPTION
This Dockerfile provides an easy-setup method to run paperbackup, even for systems which install a more modern python version than paperbackup can tolerate (see https://github.com/intra2net/paperbackup/issues/19) like Ubuntu 22.04.

Thanks for paperbackup, devs!